### PR TITLE
Put content into User Community appendix

### DIFF
--- a/WSSSPE3/report/wg_appendix_user_community.tex
+++ b/WSSSPE3/report/wg_appendix_user_community.tex
@@ -3,7 +3,9 @@
 \label{sec:appendix_user_community}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\todo{add POC here}
+POC:
+Dan Gunter <dkgunter@lbl.gov> and 
+Ethan Davis <edavis@lbl.gov>
 
 \subsection{Group Members}
 
@@ -17,6 +19,45 @@
 \end{itemize}
 
 \subsection{Summary of Discussion}
+
+Discussion revolved around a few questions: what is the benefit of having a
+``community'' for software sustainability, what practices and circumstances lead
+to having and maintaining a community, how can funding help or hinder this
+process, and perhaps most importantly, how can best practices be described and
+distilled into a document that can help new projects.
+
+The benefits of having a community that were brought up were considered largely
+obvious. In addition to having advocates for the software, and a possible source
+of ``free'' contributions to the codebase, the community becomes a good source
+for requirements, feedback, and metrics. The software community can also act as
+``cheerleaders'' who convince funders or other potential users to fund/use the
+software, and thus help sustain the software.
+
+Practices and circumstances that lead to a community are first, that the
+software offers value. But in addition to this, a community will be much more
+likely to form if they receive (expert) support when they have questions.
+Additional contributing factors are good usability (not always needed), and an
+open development process such as IPython developer meetings on YouTube. It was
+also pointed out that an evangelist for the project, not necessarily but often
+one of the developers, can often make a big difference.
+
+Funding can help the process by encouraging both value to the community and
+high-quality user support. Only providing funding for the software development
+may create good software, but with less likelihood to have a real community. It
+was discussed that federal laboratories are a good incubator for software
+communities, and that a general facility like EarthCube is too dispersed to
+really make a community. Also, domain-specific groups within laboratories or
+universities might provide as an incubator for software communities.
+
+In describing best practices, the group discussed the different modes for
+starting a scientific software project: building on an existing product that
+needs improving, recognizing an unsatisfied need of an existing community, or
+creating a new solution to a need not yet recognized by the community. The group
+also thought that the existing books on software communities would need to be
+evaluated in light of differences between Science Software projects and general
+OSS projects in terms of scale, science, acknowledgement and credit, and funding
+models.
+
 
 \subsection{Description of Opportunity, Challenges, and Obstacles}
 
@@ -34,6 +75,17 @@ expectations around scientific software.
 
 \subsection{Key Next Steps}
 
+The most important next steps is a ``Best Practice'' document, which would
+describe what successful projects with engaged communities look like, how to
+replicate this type of project, and look at end-of-life on a community project.
+Inputs to this document would include a software community survey of highly
+functioning communities such as R Open Science, Python SciPy, OPeNDAP, and
+Unidata, with analysis of factors that feed into their success. Also references
+like the ``Art of Community'' could be adapted and summarized for the science
+software community.
+
+More specifically, the group would like to take the following steps:
+
 \begin{itemize}
 \item Survey successful science software projects
 \item Survey community members from the surveyed projects
@@ -41,13 +93,50 @@ expectations around scientific software.
 \item Look for ways to raise awareness
 \end{itemize}
 
+Another next step would be increasing recognition of need for science software
+projects to focus on building and supporting their user communities. Good software
+engineering practices are not enough, and popular training like Software
+Carpentry does not currently address this issue head on.
+
 \subsection{Plan for Future Organization}
+
+No definite plans were agreed upon for future organizaton. The major ideas discussed
+were coordinating with another group or adapting some existing text.
+
+Collaboration within the framework of an existing organization seems a good initial
+path. Mozilla Science maintains a ``Working Open Project
+Guide''~\cite{working-open-wssspe3}, the introduction of which states:
+\begin{quote}
+Working openly with contributors enables your community to learn how to build
+and collaborate together. This document is a guideline on how to work openly and
+involve others in your projects with Mozilla. We want to help you engage your
+community in a way that encourages contributors and builds other leaders.
+ \end{quote}
+
+ Another idea is to form a group that could adapt existing commercial-oriented 
+ guidelines for the world of scientific software and top-down funding structures.
+ For example, to distill the ``Art of Community'' by Jono Bacon~\cite{art-of-community}
+for scientific software.
 
 
 \subsection{What Else is Needed?}
 
+The group had many points of agreement, but there is not currently a dedicated core group
+of people who have committed to producing the key milestones. Coordination via phone or
+online would be necessary to build this ``community'' of contributors.
 
 \subsection{Key Milestones and Responsible Parties}
 
+The key milestones for the group's activities align closely with the Key Next Steps above:
+
+\begin{itemize}
+\item Complete and write up a survey of project members, and community members, for successful science software projects
+\item Distill the survey results and document best practices around community engagement
+\end{itemize}
+
 
 \subsection{Description of Funding Needed}
+
+With a small amount of seed funding, it is possible that members of this group or other parties could
+spend the time necessary to devise a survey of existing projects and deploy this, probably including traveli to
+meetings and workshops for the various software communities.

--- a/WSSSPE3/report/wg_main_best_practices.tex
+++ b/WSSSPE3/report/wg_main_best_practices.tex
@@ -2,7 +2,9 @@
 \label{sec:best-practices}
 
 %\subsubsection{Why it is important}
-Reviewing multiple past articles and talks at different meetings like WSSSPEx\cite{WSSSPE papers, heroux paper, ...} and 
+Reviewing multiple past articles and talks at different meetings like WSSSPEx
+%\cite{WSSSPE papers, heroux paper, ...} 
+and 
 analyzing and promoting sustainable scientific software makes it clear that there 
 are several common and recurring ideas that underpin success in developing sustainable software. However, outside of a small community, this knowledge is not widely
 shared. This is  especially true for the large community of scientists who generate most of the software used by scientists but are not primarily software developers. In this

--- a/WSSSPE3/report/wg_main_user_community.tex
+++ b/WSSSPE3/report/wg_main_user_community.tex
@@ -12,28 +12,11 @@ and improvement.
 
 \subsubsection{Fit with related activities}
 
-Mozilla Science maintains a ``Working Open Project
-Guide''~\cite{working-open-wssspe3}, the introduction of which states:
-\begin{quote}
-Working openly with contributors enables your community to learn how to build
-and collaborate together. This document is a guideline on how to work openly and
-involve others in your projects with Mozilla. We want to help you engage your
-community in a way that encourages contributors and builds other leaders.
- \end{quote}
-
-\katznote{the next little bit needs some work, as Choi points out}
-
-Several books have been written about software communities: \choinote{only 1 book below}
-\begin{itemize}
-
-\item ``Art of Community'' by Jono Bacon~\cite{art-of-community}. We could
-consider distilling this for scientific software.
-
-\item Iain Larmour, from EPSRC in the UK (EPSRC: https://www.epsrc.ac.uk/) (not
-sure who from mentioned UK Collaborative Computational Projects (CCP:
-http://ccp.ac.uk) \choinote{Who is ``not sure who'' supposed to be?}
-
-\end{itemize}
+There are a number of activities already in progress that are targeted at improving
+the user community for open-source software, including Mozilla Science's ``Working Open Project
+Guide''~\cite{working-open-wssspe3} and
+``UK Collaborative Computational Projects'' (CCP: http://www.ccp.ac.uk), or 
+ books such as ``Art of Community'' by Jono Bacon~\cite{art-of-community}. 
 
 \subsubsection{Discussion}
 
@@ -43,37 +26,11 @@ to having and maintaining a community, how can funding help or hinder this
 process, and perhaps most importantly, how can best practices be described and
 distilled into a document that can help new projects.
 
-The benefits of having a community that were brought up were considered largely
-obvious. In addition to having advocates for the software, and a possible source
-of ``free'' contributions to the codebase, the community becomes a good source
-for requirements, feedback, and metrics. The software community can also act as
-``cheerleaders'' who convince funders or other potential users to fund/use the
-software, and thus help sustain the software.
-
-Practices and circumstances that lead to a community are first, that the
-software offers value. But in addition to this, a community will be much more
-likely to form if they receive (expert) support when they have questions.
-Additional contributing factors are good usability (not always needed), and an
-open development process such as IPython developer meetings on YouTube. It was
-also pointed out that an evangelist for the project, not necessarily but often
-one of the developers, can often make a big difference.
-
-Funding can help the process by encouraging both value to the community and
-high-quality user support. Only providing funding for the software development
-may create good software, but with less likelihood to have a real community. It
-was discussed that federal laboratories are a good incubator for software
-communities, and that a general facility like EarthCube is too dispersed to
-really make a community. Also, domain-specific groups within laboratories or
-universities might provide as an incubator for software communities.
-
-In describing best practices, the group discussed the different modes for
-starting a scientific software project: building on an existing product that
-needs improving, recognizing an unsatisfied need of an existing community, or
-creating a new solution to a need not yet recognized by the community. The group
-also thought that the existing books on software communities would need to be
-evaluated in light of differences between Science Software projects and general
-OSS projects in terms of scale, science, acknowledgement and credit, and funding
-models.
+Everyone agreed on a few points: software must not only offer value, but there
+must be some support for users; and funding can help pay for that support, in
+addition to the usual funding for software development. Openness is generally 
+a virtue. An evangelist, either in the form of a single person or some
+domain-specific group of users, is often the key factor.
 
 Additional details on the group's discussion can be found in
 Appendix~\ref{sec:appendix_user_community}.
@@ -83,16 +40,10 @@ Appendix~\ref{sec:appendix_user_community}.
 The most important next steps is a ``Best Practice'' document, which would
 describe what successful projects with engaged communities look like, how to
 replicate this type of project, and look at end-of-life on a community project.
-Inputs to this document would include a software community survey of highly
-functioning communities such as R Open Science, Python SciPy, OPeNDAP, and
-Unidata, with analysis of factors that feed into their success. Also references
-lik the ``Art of Community'' could be adapted and summarized for the science
-software community.
-
-Another next step would be increasing recognition of need for science software
-projects to focus on building and supporting their user communities. Good software
-engineering practices are not enough, and popular training like Software
-Carpentry does not currently address this issue head on.
+Another next step would be better training to increase recognition of need for science software
+projects to focus on building and supporting their user communities.
 
 \subsubsection{Landing Page}
-\todo{link to landing page}
+
+This group doesn't have a landing page yet. Please send requests to join and contribute to both
+Dan Gunter <dkgunter@lbl.gov> and Ethan Davis <edavis@ucar.edu>.


### PR DESCRIPTION
Largely by moving text around, I got some content in the User Community WG appendix. The main section became much shorter of course.

I also made one tweak in the "best practices" WG text so my Latex build would succeed, commenting out a citation that pointed nowhere.

@ethanrd please take a look when you have a chance. I included your name as the POC (along with mine).