### PR TITLE
Small changes to Software Credit working group

### DIFF
--- a/WSSSPE3/report/wg_appendix_software_credit.tex
+++ b/WSSSPE3/report/wg_appendix_software_credit.tex
@@ -19,7 +19,7 @@ ensuring timely progress of the planned actions.
 \item Lorraine Hwang -- University of California, Davis
 \item Daniel S.\ Katz -- University of Chicago, Argonne National Laboratory
 \item Frank L\"{o}ffler -- Louisiana State University
-\item Abby Cabunoc Mayes -- Mozilla Science Lab
+\item Abigail Cabunoc Mayes -- Mozilla Science Lab
 \item Kyle E.\ Niemeyer -- Oregon State University
 \item Grace Peng -- National Center for Atmospheric Research
 \item Ilian Todorov -- Science \& Technology Facilities Council, UK
@@ -54,8 +54,8 @@ based on their specific contributions; and
     
 \item Mozilla Science Lab's recently introduced Contributorship Badges for
 Science~\cite{Mozilla_badges}, which provide a badge---associated with
-ORCID~\cite{orcid}---based on author contributions in a similar manner to
-Project CRediT.
+ORCID~\cite{orcid}---for author contributions based on the taxonomy
+outlined in Project CRediT.
     
 \end{itemize}
 However, as of this writing, only Project CRediT
@@ -138,7 +138,7 @@ includes:
 \end{itemize}
 This information would then be contained in a citation file, e.g., as part of
 the GitHub repository. The group also discussed similar efforts such as
-Codemeta\footnote{Codemeta: \url{https://github.com/codemeta/codemeta}}, an
+CodeMeta\footnote{CodeMeta: \url{https://github.com/codemeta/codemeta}}, an
 attempt to codify minimal metadata schemes in JSON and XML for scientific
 software and code, and implementing transitive credit via
 JSON-LD~\cite{wssspe2_katz}. Some questions arose about how this information


### PR DESCRIPTION
* Use my full name
* clarify description of Mozilla Science's Contributorship Badges for Science & relationship with Project CRediT
* Codemeta -> CodeMeta