### PR TITLE
Use standard colors for links and references.

### DIFF
--- a/WSSSPE4_report/WSSSPE4_report.tex
+++ b/WSSSPE4_report/WSSSPE4_report.tex
@@ -48,7 +48,7 @@
 %\setcounter{secnumdepth}{3}
 %\setcounter{tocdepth}{3}
 
-\usepackage[bookmarks, bookmarksopen, bookmarksnumbered]{hyperref}
+\usepackage[bookmarks, bookmarksopen, bookmarksnumbered, colorlinks,linkcolor=blue,urlcolor=blue,citecolor=blue]{hyperref}
 \usepackage[all]{hypcap}
 \urlstyle{rm}
 


### PR DESCRIPTION
It turns out that the latex package 'hyperref' has its very own color scheme that
appears to date back to the 1990s. Today, we essentially have a standard on the WWW
that links are shown in blue -- not in green, and not with a box around it. I keep
thinking how ugly and unprofessional that looks :-)

So here is a patch that uses a more standards-conforming style. These things are
personal -- I'm just proposing, feel free to decline to merge if you think this
is silly.